### PR TITLE
Change protected division to return 1 when denominator is zero

### DIFF
--- a/src/propel/core.cljc
+++ b/src/propel/core.cljc
@@ -147,7 +147,7 @@
   (single-result-push-instruction state
                          (fn [int1 int2]
                            (if (zero? int2)
-                             int1
+                             1
                              (quot int1 int2)))
                          [:integer :integer]
                          :integer))

--- a/test/propel/core_test.clj
+++ b/test/propel/core_test.clj
@@ -65,7 +65,7 @@
       (= '(11 999)
       (:integer (integer_% (load-state {:integer '(9 99 999)})))))
     (is
-      (= '(99 999) ;; % returns numerator when dividing by zero
+      (= '(1 999) ;; % returns 1 when dividing by zero
       (:integer (integer_% (load-state {:integer '(0 99 999)})))))
     (is
       (= '(0 999) ;; checks arg order


### PR DESCRIPTION
Having protected division return 1 allows evolved systems to use
x/x as a reliable source of the constant 1, which I think is a lot more
useful than having it return the numerator.